### PR TITLE
Fix absolute twitter image URL

### DIFF
--- a/src/components/OpenGraph.astro
+++ b/src/components/OpenGraph.astro
@@ -18,4 +18,4 @@ const imageUrl = new URL(image, Astro.url).toString();
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
-<meta name="twitter:image" content={image} />
+<meta name="twitter:image" content={imageUrl} />


### PR DESCRIPTION
## Summary
- use absolute image URL for twitter cards, matching Open Graph

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68415c118414832f86dd34c3b3f9b451